### PR TITLE
fixes adds and replace operations with null and false values

### DIFF
--- a/jsonpatch.js
+++ b/jsonpatch.js
@@ -167,7 +167,7 @@
         for (key in patch) {
           if (!(method = methodMap[key])) continue;
           if (this.operation) throw new InvalidPatchError();
-          if ((member = operationMembers[key]) && !patch[member]) {
+          if ((member = operationMembers[key]) && patch[member] === undefined) {
             throw new InvalidPatchError("Patch member " + member + " not defined");
           }
           this.operation = methodMap[key];

--- a/test.js
+++ b/test.js
@@ -27,6 +27,22 @@ test('add', function() {
     raises(function() {
         jsonpatch.apply(obj, [{add: '/bar/-1', value: '5'}]);
     }, jsonpatch.PatchConflictError, 'Out of bounds (lower)');
+
+    raises(function() {
+        jsonpatch.apply(obj, [{add: '/bar/8', value: undefined}]);
+    }, jsonpatch.InvalidPatchError, 'Patch member value not defined');
+
+    obj = {foo: 1, baz: [{qux: 'hello'}]};
+    jsonpatch.apply(obj, [{add: '/bar', value: true}]);
+    deepEqual(obj, {foo: 1, baz: [{qux: 'hello'}], bar: true});
+
+    obj = {foo: 1, baz: [{qux: 'hello'}]};
+    jsonpatch.apply(obj, [{add: '/bar', value: false}]);
+    deepEqual(obj, {foo: 1, baz: [{qux: 'hello'}], bar: false});
+
+    obj = {foo: 1, baz: [{qux: 'hello'}]};
+    jsonpatch.apply(obj, [{add: '/bar', value: null}]);
+    deepEqual(obj, {foo: 1, baz: [{qux: 'hello'}], bar: null});
 });
 
 


### PR DESCRIPTION
Applying a patch with add and replace operations was failing if the value property was null or false.  Explicitly comparing the value to undefined fixes this.
