### PR TITLE
Fixed PatchConflictError message

### DIFF
--- a/jsonpatch.js
+++ b/jsonpatch.js
@@ -181,7 +181,7 @@
             step = parseInt(step, 10);
           }
           if (!(step in parent)) {
-            throw new PatchConflictError('Array location out of ', 'bounds or not an instance property');
+            throw new PatchConflictError('Array location out of bounds or not an instance property');
           }
           parent = parent[step];
         }


### PR DESCRIPTION
When attempting to apply a patch to an array location is out of bounds or a child of a non-existent object, jsonpatch throws a `PatchConflictError` stating such. For whatever reason, the message was split across two parameters and the message property was only set to `"Array location out of "`. This change should fix that.
