### PR TITLE
The '-' accessor can be used with the replace operation

### DIFF
--- a/jsonpatch.coffee
+++ b/jsonpatch.coffee
@@ -249,6 +249,8 @@
 
             if isArray(reference)
                 accessor = @path.coerce(reference, accessor)
+                if @path.accessor is '-'
+                    accessor--;
                 if accessor not of reference
                     throw new PatchConflictError("Value at #{accessor} does not exist")
                 reference.splice(accessor, 1, value)

--- a/jsonpatch.js
+++ b/jsonpatch.js
@@ -324,6 +324,11 @@
         }
         if (isArray(reference)) {
           accessor = this.path.coerce(reference, accessor);
+
+          if (this.path.accessor === '-') {
+            accessor--;
+          }
+
           if (!(accessor in reference)) {
             throw new PatchConflictError("Value at " + accessor + " does not exist");
           }

--- a/test.js
+++ b/test.js
@@ -66,6 +66,9 @@ test('replace', function() {
 
     jsonpatch.apply(obj, [{op: 'replace', path: '/baz/0/qux', value: 'world'}]);
     deepEqual(obj, {foo: [1, 2, 3, 4], baz: [{qux: 'world'}]});
+
+    jsonpatch.apply(obj, [{op: 'replace', path: '/foo/-', value: 42}]);
+    deepEqual(obj, {foo: [1, 2, 3, 42], baz: [{qux: 'world'}]});
 });
 
 


### PR DESCRIPTION
I don't know if it's against the rfc6902 specification, but it appears to be very usefull in many cases.
